### PR TITLE
refactor: renomeia componente para sboot-security-base-auth-service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
     </parent>
 
     <groupId>org.com</groupId>
-    <artifactId>saas-holerite-bff-gateway</artifactId>
+    <artifactId>sboot-security-base-auth-service</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <name>saas-holerite-bff-gateway</name>
+    <name>sboot-security-base-auth-service</name>
     <description>BFF Gateway para autenticação e autorização via JWT</description>
 
     <properties>

--- a/src/main/java/org/com/gateway/SbootSecurityBaseAuthServiceApplication.java
+++ b/src/main/java/org/com/gateway/SbootSecurityBaseAuthServiceApplication.java
@@ -4,9 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class SaasHoleriteBffGatewayApplication {
+public class SbootSecurityBaseAuthServiceApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(SaasHoleriteBffGatewayApplication.class, args);
+        SpringApplication.run(SbootSecurityBaseAuthServiceApplication.class, args);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,8 @@ security:
     expiration-seconds: 3600
 
 spring:
+  application:
+    name: sboot-security-base-auth-service
   datasource:
     url: "${DB_URL}"
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
### Motivation
- O propósito do componente mudou e é necessário atualizar o identificador e a classe principal para refletir o novo nome e responsabilidade.

### Description
- Atualizado o `artifactId` e o `name` no `pom.xml` de `saas-holerite-bff-gateway` para `sboot-security-base-auth-service`.
- Renomeada a classe e o ficheiro principal de aplicação de `SaasHoleriteBffGatewayApplication` para `SbootSecurityBaseAuthServiceApplication` e ajustada a chamada `SpringApplication.run(...)`.
- Adicionado `spring.application.name: sboot-security-base-auth-service` em `src/main/resources/application.yml` para manter consistência do nome da aplicação no runtime.

### Testing
- Executado `mvn test -q`, que falhou ao resolver dependências devido a acesso restrito ao repositório Maven Central (HTTP 403) no ambiente de execução.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b7c8a10c832197ba3ba93d7c5678)